### PR TITLE
Fix revision date on docs pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material 
-      - run: pip install mkdocs-git-revision-date-plugin
+      - run: pip install mkdocs-material mkdocs-git-revision-date-localized-plugin
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
When using the [mkdocs-git-revision-date-localized](https://pypi.org/project/mkdocs-git-revision-date-localized-plugin/) plugin with the [checkout GitHub Action](https://github.com/actions/checkout), the revision date on every page always refers to the last commit in the repo, rather than the last commit that touched the file. According to the docs, the way to fix this is to set `fetch-depth` to 0 in the checkout action (the default is 1).