### PR TITLE
Add contribution guide and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/spec-change-request.md
+++ b/.github/ISSUE_TEMPLATE/spec-change-request.md
@@ -1,0 +1,20 @@
+---
+name: Spec change request
+about: Suggest a change for the spec
+title: "[SPEC CHANGE]"
+labels: ''
+assignees: ''
+
+---
+
+**Is your spec change request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We use GitHub Issues to centralize discussions around spec changes. Once an issu
 
 #### Create a new issue
 
-If you'd like to propose a change to the spec, search to see if there's already an issue. If a related issue doesn't exist, you can open a new issue using the issue form.
+If you'd like to propose a change to the spec, [search to see if there's already an issue](https://github.com/searchdiscovery/client-kenvue-ga4-dl-spec/issues). If a related issue doesn't exist, you can [open a new issue using the issue form](https://github.com/searchdiscovery/client-kenvue-ga4-dl-spec/issues/new).
 
 #### Solve an issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Welcome to the Kenvue GA4 Data Layer Spec contributing guide
+
+Thank you for your interest in contributing to the Kenvue GA4 Data Layer Spec!
+
+In this guide you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
+
+## Workflow
+
+When we need to make changes to the spec, we follow this general workflow to ensure changes are in the spirit of the spec, are free from typos and broken links, and have the approval of at least one other contributor:
+1. Create a new issue to discuss the approach for the changes
+2. Create a branch linked to the issue to group related changes
+3. Once changes are ready, create a pull request (PR) linked to the original issue
+4. Once the PR is approved by at least one other person, it is merged into main and published to GitHub Pages
+
+### Issues
+
+We use GitHub Issues to centralize discussions around spec changes. Once an issue has been discussed and we're ready to make a change, we open a new branch to modify the spec to address the issue. Branches must be linked to issues so other contributors have the necessary context during the review process.
+
+#### Create a new issue
+
+If you'd like to propose a change to the spec, search to see if there's already an issue. If a related issue doesn't exist, you can open a new issue using the issue form.
+
+#### Solve an issue
+
+Some issues are assigned to certain users. If you see an issue which isn't assigned to anyone, feel free to create a branch and open a PR for it.
+
+### Make Changes
+
+#### Make changes using the UI
+
+You can use the GitHub UI to make small changes such as fixing a typo or a broken link. For larger sets of changes, consider using a codespace or making changes locally.
+
+#### Make changes in a codespace
+
+If you don't have a local git environment on your device, you can use GitHub Codespaces to make larger sets of changes.
+
+#### Make changes locally
+
+If you prefer to make changes locally, you can clone the repo using GitHub Desktop or using the command line. Don't forget to create a new branch — you may not commit directly to the main branch in this repository.
+
+### Commit your changes
+
+Once you're done with your changes, you can commit them to the repo.
+
+### Pull Request
+
+When you're finished with your changes, create a pull request (aka PR) so that others can review them.
+- All PRs must have approval from at least one reviewer. This is to reduce the risk that a spec change slips in unnoticed by other contributors.
+- Please provide a brief description of your changes so that reviewers know what you changed and why.
+- Make sure your PR is linked to the original issue.
+
+### Merging
+
+Once your PR is approved, you may merge it yourself if the approver doesn't do it for you. Your changes will appear on the docs site in ~2–5 minutes.


### PR DESCRIPTION
In order to increase the odds that changes to the data layer spec go through the appropriate review process, I've added a [CONTRIBUTING.md](https://github.com/searchdiscovery/client-kenvue-ga4-dl-spec/blob/c3b805a80290b8f60faed0c924295b6ef99dba25/CONTRIBUTING.md) file (in line with other GitHub repos) and two issue templates.

This won't prevent anyone from committing directly to `main`. We have a branch protection rule for `main`, but it's not enforced, since we don't have a GitHub Enterprise account. What I hope it will do is outline a sustainable workflow that all contributors can adhere to so that changes are being discussed with other contributors and are in line with the long-term vision of the data layer spec.